### PR TITLE
Fix mobile nav toggle and expand hero video

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -45,14 +45,14 @@ a{color:inherit;text-decoration:none}
 }
 
 /* Hero */
-.hero{position:relative;min-height:70vh} 
-.video-wrap{position:relative;min-height:70vh;overflow:hidden;border-radius:0 0 var(--radius) var(--radius)}
+.hero{position:relative;min-height:100vh}
+.video-wrap{position:relative;min-height:100vh;overflow:hidden;border-radius:0 0 var(--radius) var(--radius)}
 /* Important: only video fills cover */
-video.hero-video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
+video.hero-video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;aspect-ratio:16/9}
 /* Static image version stays in flow */
 .hero img.hero-video{position:static;width:100%;height:auto;display:block}
 .hero-overlay{
-  position:relative;z-index:2;display:grid;place-items:center;min-height:70vh;
+  position:relative;z-index:2;display:grid;place-items:center;min-height:100vh;
   padding:clamp(2rem,6vw,8rem) 1rem;
   background:linear-gradient(to bottom, rgba(0,0,0,.30), rgba(0,0,0,.15), transparent 60%);
   color:#fff;text-align:center

--- a/js/main.js
+++ b/js/main.js
@@ -73,7 +73,19 @@
     if (toggle) toggle.setAttribute('aria-expanded', 'false');
     document.body.style.overflow = '';
   };
-  on(toggle, 'click', () => nav?.classList.contains('open') ? closeNav() : openNav());
+
+  const handleToggle = (e) => {
+    if (e) e.preventDefault();
+    if (!nav) return;
+    if (nav.classList.contains('open')) {
+      closeNav();
+    } else {
+      openNav();
+    }
+  };
+
+  on(toggle, 'click', handleToggle);
+  on(toggle, 'touchstart', handleToggle);
   on(document, 'keydown', (e) => { if (e.key === 'Escape') closeNav(); });
   // Close on any nav link click (good for mobile)
   on(nav, 'click', (e) => { if (e.target.closest('a')) closeNav(); });
@@ -164,7 +176,8 @@
     $$('#main [data-lightbox] .gallery-item').forEach((a) => {
       on(a, 'click', (e) => {
         e.preventDefault();
-        const href = a.getAttribute('href') || a.querySelector('img')?.src;
+        const imgEl = a.querySelector('img');
+        const href = a.getAttribute('href') || (imgEl ? imgEl.src : '');
         if (!href || !lbImg) return;
         lbImg.src = href;
         lightbox.classList.add('open');


### PR DESCRIPTION
## Summary
- ensure navigation menu opens on tap by adding touch support and removing unsupported optional chaining
- resize hero video container to fill the viewport at 16:9 for a full-screen intro